### PR TITLE
Added `show_diff` param to file type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,12 +93,13 @@ class mcafee_epo_agent (
         'script': {
           $agent_install_script_real = '/tmp/McAfee-Install.sh'
           file{ $agent_install_script:
-            ensure => 'present',
-            path   => $agent_install_script_real,
-            source => $agent_install_script,
-            mode   => '0700',
-            owner  => 'root',
-            group  => 'root',
+            ensure    => 'present',
+            path      => $agent_install_script_real,
+            source    => $agent_install_script,
+            mode      => '0700',
+            owner     => 'root',
+            group     => 'root',
+            show_diff => false,
           }
           exec{ $agent_install_script:
             command => "${agent_install_script_real} ${agent_install_options}",


### PR DESCRIPTION
- adds the `show_diff` parameter and sets it to false in an attempt to not show the diff of the install script as it may include an embedded binary which causes the diff to break and the agent run to fail
- realigned other params according to style guide

Addresses #5.

Note: this could also be done by adding a param to the module to turn this feature on/off or provide subsequent options to the file but this would be more complicated than simply telling Puppet not to diff the file, which is not only easy but shouldn't be a big deal...

Please let me know if there are any questions.